### PR TITLE
feat: add extension for intel-ucode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ COMMON_ARGS += --build-arg=https_proxy=$(https_proxy)
 empty :=
 space = $(empty) $(empty)
 
-TARGETS =  gvisor
+TARGETS =  gvisor intel-ucode
 NONFREE_TARGETS =
 
 all: $(TARGETS) ## Builds all known pkgs.
@@ -63,4 +63,3 @@ kernel-%: ## Updates the kernel configs: e.g. make kernel-olddefconfig; make ker
 .PHONY: conformance
 conformance: ## Performs policy checks against the commit and source code.
 	docker run --rm -it -v $(PWD):/src -w /src ghcr.io/talos-systems/conform:v0.1.0-alpha.22 enforce
-

--- a/intel-ucode/manifest.yaml
+++ b/intel-ucode/manifest.yaml
@@ -1,0 +1,10 @@
+version: v1alpha1
+metadata:
+  name: intel-ucode
+  version: microcode-20210608-v1.0.0
+  author: Spencer Smith
+  description: |
+    This system extension provides Intel microcode binaries.
+  compatibility:
+    talos:
+      version: ">= v1.0.0"

--- a/intel-ucode/pkg.yaml
+++ b/intel-ucode/pkg.yaml
@@ -1,0 +1,23 @@
+name: intel-ucode
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+steps:
+  - sources:
+      - url: https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/archive/refs/tags/microcode-20210608.tar.gz
+        destination: intel-ucode.tar.gz
+        sha256: fd85b6b769efd029dec6a2c07106fd18fb4dcb548b7bc4cde09295a8344ef6d7
+        sha512: 61acd2e76aa019fa0002fbf56c503791080a937ff93d81e020f8f0cc089dc08928b4c7e9884f713b886e2f9d4a8409fea59e39f628ef534a588515e1c3fc861d
+    prepare:
+      - |
+        tar -xzf intel-ucode.tar.gz --strip-components=1
+    install:
+      - |
+        mkdir -p /rootfs/lib/firmware
+        cp -R -p intel-ucode /rootfs/lib/firmware
+finalize:
+  - from: /rootfs
+    to: /rootfs
+  - from: /pkg/manifest.yaml
+    to: /


### PR DESCRIPTION
This PR adds in the ability to install the intel ucode binaries as a
system extension.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>