### PR TITLE
feat: add broadcom netextreme 2 (bnx2/bnx2x) extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ COMMON_ARGS += --build-arg=https_proxy=$(https_proxy)
 empty :=
 space = $(empty) $(empty)
 
-TARGETS = amd-ucode gvisor intel-ucode
+TARGETS = amd-ucode bnx2-bnx2x gvisor intel-ucode
 NONFREE_TARGETS =
 
 all: $(TARGETS) ## Builds all known pkgs.

--- a/bnx2-bnx2x/manifest.yaml
+++ b/bnx2-bnx2x/manifest.yaml
@@ -1,0 +1,10 @@
+version: v1alpha1
+metadata:
+  name: bnx2-bnx2x
+  version: 20211216-v1.0.0
+  author: Spencer Smith
+  description: |
+    This system extension provides bnx2 and bnx2x binaries.
+  compatibility:
+    talos:
+      version: "> v0.15.0-alpha.1"

--- a/bnx2-bnx2x/pkg.yaml
+++ b/bnx2-bnx2x/pkg.yaml
@@ -1,0 +1,17 @@
+name: bnx2-bnx2x
+variant: scratch
+shell: /toolchain/bin/bash
+dependencies:
+  - stage: base
+  - image: "{{ .LINUX_FIRMWARE_IMAGE }}"
+steps:
+  - install:
+      - |
+        mkdir -p /rootfs/lib/firmware
+        cp -R -p /lib/firmware/bnx2 /rootfs/lib/firmware
+        cp -R -p /lib/firmware/bnx2x /rootfs/lib/firmware
+finalize:
+  - from: /rootfs
+    to: /rootfs
+  - from: /pkg/manifest.yaml
+    to: /


### PR DESCRIPTION
This PR adds bnx2/bnx2x from linux-firmware.

Signed-off-by: Spencer Smith <spencer.smith@talos-systems.com>