### PR TITLE
chore: bump golang from tools to 1.17.7

### DIFF
--- a/Pkgfile
+++ b/Pkgfile
@@ -3,7 +3,7 @@
 format: v1alpha2
 
 vars:
-  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.10.0-alpha.0-1-g67314b1
+  TOOLS_IMAGE: ghcr.io/talos-systems/tools:v0.10.0-alpha.0-3-g4c9e7a4
   LINUX_FIRMWARE_IMAGE: ghcr.io/talos-systems/linux-firmware:v0.9.0-2-g447ce75
 
 labels:


### PR DESCRIPTION
Bump golang to 1.17.7

Ref: https://github.com/talos-systems/tools/pull/168

Signed-off-by: Noel Georgi <git@frezbo.dev>